### PR TITLE
Copy payload buffer in parser

### DIFF
--- a/frame/parser.go
+++ b/frame/parser.go
@@ -210,7 +210,7 @@ func (p *Parser) processByte(currentByte byte) {
 		p.state.Event("RX_CHECKSUM", currentByte)
 		p.state.Transition()
 
-		payload := p.payloadReadBuffer.Bytes()
+		payload := append([]byte(nil), p.payloadReadBuffer.Bytes()...)
 		frame := Frame{
 			Header:   p.sof,
 			Length:   p.length,


### PR DESCRIPTION
Parser can overwrite the underlying buffer from payloadReadBuffer that is used in other parts of the stack causing panics and headaches.